### PR TITLE
Fix: configurar base path para GitHub Pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,6 @@ import react from '@vitejs/plugin-react-swc'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/jobee-frontend/',
   server: { fs: { allow: ['..'] } }
 })


### PR DESCRIPTION
Agrega `base: '/jobee-frontend/'` en vite.config.js para que los assets se carguen correctamente en GitHub Pages.